### PR TITLE
fixed bug where negative unary expressions were given a true type

### DIFF
--- a/src/ccBooleanAnalysis.js
+++ b/src/ccBooleanAnalysis.js
@@ -747,7 +747,7 @@
         if (!(negative_regulator_name in negative_holder.data)) {
           negative_holder.data[negative_regulator_name] = {
             component: negative_regulator_name,
-            type: true
+            type: false
           };
         }
       } else { // kOR


### PR DESCRIPTION
Haven't tested on the new ES6 codebase, but this should solve the issue!

Previously, a process fails on a simple scenario where the expression is ~B -- B gets translated as a positive regulator.

 { regulators: [ { component: 'B', type: true } ], 
  absentState: false }